### PR TITLE
refactor: rename run to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Alpha warning**: This library is in early alpha and is not ready for production use.
 
-Typed helpers to build Next.js App Router pages, layouts, server components, and server actions with Effect. Compose middlewares as `Context.Tag`s, validate params/search params/input with `Schema`, and run your `Effect` programs with a single call.
+Typed helpers to build Next.js App Router pages, layouts, server components, and server actions with Effect. Compose middlewares as `Context.Tag`s, validate params/search params/input with `Schema`, and build your `Effect` programs with a single call.
 
 ### Getting Started
 
@@ -41,7 +41,7 @@ export const page = Next.make(AppLive)
   .page("HomePage")
   .setParamsSchema(Schema.Struct({ id: Schema.String }))
   .middleware(AuthMiddleware)
-  .run(({ params }) =>
+  .build(({ params }) =>
     Effect.gen(function* () {
       const user = yield* CurrentUser
       return <div>Hello {user.name}</div>
@@ -57,7 +57,7 @@ import { page } from "@/lib/app" // wherever you defined it
 
 const page = Next.make(AppLive)
   .page("HomePage")
-  .run(({ params }) =>
+  .build(({ params }) =>
     Effect.gen(function* () {
       const user = yield* CurrentUser
       return <div>Hello {user.name}</div>
@@ -82,8 +82,8 @@ Notes
 - Use `.layout(tag)`, `.component(tag)`, and `.action(tag)` for layouts, server components, and server actions.
 - Validate search params with `.setSearchParamsSchema(...)` on pages, and action input with `.setInputSchema(...)` on actions.
 - Add multiple middlewares with `.middleware(...)`. Middlewares can be marked `optional` or `wrap` via the tag options.
-- Provide a custom error mapping with `.run(build, onError)`.
-- Server actions: due to Next.js restrictions, the action handler must be declared with the `async` keyword. In this API, that means the function you pass to `.run(...)` for actions must be `async`, returning a Promise of an Effect.
+- Provide a custom error mapping with `.build(handler, onError)`.
+- Server actions: due to Next.js restrictions, the action handler must be declared with the `async` keyword. In this API, that means the function you pass to `.build(...)` for actions must be `async`, returning a Promise of an Effect.
 
 ### Middlewares with dependencies
 
@@ -122,7 +122,7 @@ const AppLive = Layer.mergeAll(OtherLive, AuthLive)
 const page = Next.make(AppLive)
   .page("Home")
   .middleware(AuthMiddleware)
-  .run(() =>
+  .build(() =>
     Effect.gen(function* () {
       const user = yield* CurrentUser
       return user
@@ -138,7 +138,7 @@ Access provided services with `yield* Tag` inside your `Effect` handler.
 const page = Next.make(AppLive)
   .page("Home")
   .middleware(AuthMiddleware)
-  .run(() =>
+  .build(() =>
     Effect.gen(function* () {
       const user = yield* CurrentUser
       // use `user` here
@@ -182,7 +182,7 @@ const AppLive = Layer.mergeAll(WrappedLive)
 const page = Next.make(AppLive)
   .page("Home")
   .middleware(Wrapped)
-  .run(() => Effect.succeed("ok"))
+  .build(() => Effect.succeed("ok"))
 ```
 
 ### OpenTelemetry integration (example)
@@ -228,19 +228,19 @@ const page = Next.make(AppLive)
   .page("Home")
   .setParamsSchema(Schema.Struct({ id: Schema.String }))
   .setSearchParamsSchema(Schema.Struct({ q: Schema.optional(Schema.String) }))
-  .run(({ params, searchParams }) => Effect.succeed({ params, searchParams }))
+  .build(({ params, searchParams }) => Effect.succeed({ params, searchParams }))
 
 // Input (Action)
 // IMPORTANT: The action handler must be async because of Next.js server action requirements
 const action = Next.make(AppLive)
   .action("DoSomething")
   .setInputSchema(Schema.Struct({ count: Schema.Number, tags: Schema.Array(Schema.String) }))
-  .run(async ({ input }) => Effect.succeed({ ok: true, input }))
+  .build(async ({ input }) => Effect.succeed({ ok: true, input }))
 
 // Server Component (no inputs):
 const component = Next.make(AppLive)
   .component("ServerInfo")
-  .run(() => Effect.succeed({ ok: true }))
+  .build(() => Effect.succeed({ ok: true }))
 ```
 
 ### Running Code

--- a/example/Action.ts
+++ b/example/Action.ts
@@ -29,7 +29,7 @@ const action = Next.make(AuthLive).action("Submit")
     })
   )
   .middleware(AuthMiddleware)
-  .run(async ({ input }) =>
+  .build(async ({ input }) =>
     Effect.gen(function*() {
       const user = yield* CurrentUser
       return { user, input }

--- a/example/Layout.ts
+++ b/example/Layout.ts
@@ -20,7 +20,7 @@ const layout = Next.make(ThemeLive)
   .layout("RootLayout")
   .setParamsSchema(Schema.Struct({ locale: Schema.String }))
   .middleware(ThemeMiddleware)
-  .run(({ params, children }) =>
+  .build(({ params, children }) =>
     Effect.gen(function*() {
       const theme = yield* Theme
       return { theme, params, children }

--- a/example/Middleware.ts
+++ b/example/Middleware.ts
@@ -54,7 +54,7 @@ const _page = Next.make(ProdLive).page("HomePage")
   // }))
   .middleware(WrappedMiddleware)
   .middleware(NotWrappedMiddleware)
-  .run(({ params }) =>
+  .build(({ params }) =>
     Effect.gen(function*() {
       const user = yield* CurrentUser
       yield* Effect.fail("error")

--- a/example/Page.ts
+++ b/example/Page.ts
@@ -20,7 +20,7 @@ const page = Next.make(ProvideUserLive)
   .page("Home")
   .setParamsSchema(Schema.Struct({ id: Schema.String }))
   .middleware(ProvideUser)
-  .run(({ params }) =>
+  .build(({ params }) =>
     Effect.gen(function*() {
       const user = yield* CurrentUser
       return { user, params }

--- a/example/ServerComponent.ts
+++ b/example/ServerComponent.ts
@@ -19,7 +19,7 @@ const TimeLive = Layer.succeed(
 const component = Next.make(TimeLive)
   .component("ServerInfo")
   .middleware(TimeMiddleware)
-  .run(() =>
+  .build(() =>
     Effect.gen(function*() {
       const time = yield* ServerTime
       return { time }

--- a/src/NextAction.ts
+++ b/src/NextAction.ts
@@ -57,11 +57,11 @@ export interface NextAction<
 
   setInputSchema<S extends Schema.Schema.All>(schema: S): NextAction<Tag, L, Middleware, S>
 
-  run<
+  build<
     InnerHandler extends HandlerFrom<NextAction<Tag, L, Middleware, InputA>>,
     OnError = never
   >(
-    build: InnerHandler,
+    handler: InnerHandler,
     onError?: (
       error: MiddlewareErrors<Middleware> | HandlerError<InnerHandler>
     ) => OnError
@@ -105,9 +105,9 @@ const Proto = {
     return makeProto(options)
   },
 
-  run(
+  build(
     this: AnyWithProps,
-    build: (ctx: any) => Promise<Effect<any, any, any>>,
+    handler: (ctx: any) => Promise<Effect<any, any, any>>,
     onError?: (error: unknown) => unknown
   ) {
     const middlewares = this.middlewares
@@ -123,7 +123,7 @@ const Proto = {
             : rawInput
           return { input: decodedInput }
         })
-        let handlerEffect = yield* Effect_.promise(() => build(payload as any))
+        let handlerEffect = yield* Effect_.promise(() => handler(payload as any))
         if (middlewares.length > 0) {
           const options = { _type: "action" as const, input: (payload as any).input }
           const tags = middlewares as ReadonlyArray<any>
@@ -302,7 +302,7 @@ export type HandlerInput<P extends Any> = P extends
   InputA extends Schema.Schema<infer encoded, infer _decoded, infer _c> ? encoded : unknown
   : never
 
-// Error typing helpers for run onError
+// Error typing helpers for build onError
 type InferSchemaType<S> = S extends Schema.Schema<infer A, any, any> ? A : never
 export type MiddlewareErrors<M> = M extends NextMiddleware.TagClassAny ? InferSchemaType<M["failure"]>
   : never

--- a/src/NextLayout.ts
+++ b/src/NextLayout.ts
@@ -71,11 +71,11 @@ export interface NextLayout<
 
   setParamsSchema<S extends AnySchema>(schema: S): NextLayout<Tag, L, Middleware, S["Type"]>
 
-  run<
+  build<
     InnerHandler extends HandlerFrom<NextLayout<Tag, L, Middleware, ParamsA>>,
     OnError = never
   >(
-    build: InnerHandler,
+    handler: InnerHandler,
     onError?: (
       error: MiddlewareErrors<Middleware> | HandlerError<InnerHandler>
     ) => OnError
@@ -121,9 +121,9 @@ const Proto = {
     return makeProto(options)
   },
 
-  run(
+  build(
     this: AnyWithProps,
-    build: (ctx: any) => Effect<any, any, any>,
+    handler: (ctx: any) => Effect<any, any, any>,
     onError?: (error: unknown) => unknown
   ) {
     const middlewares = this.middlewares
@@ -145,7 +145,7 @@ const Proto = {
           const children = props?.children
           return { params: decodedParams, children }
         })
-        let handlerEffect = build(payload as any) as Effect<any, any, any>
+        let handlerEffect = handler(payload as any) as Effect<any, any, any>
         if (middlewares.length > 0) {
           const options = { _type: "layout" as const, params: props?.params, children: props?.children }
           const tags = middlewares as ReadonlyArray<any>
@@ -313,7 +313,7 @@ export type Params<P extends Any> = P extends NextLayout<infer _Tag, infer _Laye
   ParamsA extends undefined ? Promise<Record<string, string>> : ParamsA
   : never
 
-// Error typing helpers for run onError
+// Error typing helpers for build onError
 type InferSchemaType<S> = S extends Schema.Schema<infer A, any, any> ? A : never
 
 export type MiddlewareErrors<M> = M extends NextMiddleware.TagClassAny ? InferSchemaType<M["failure"]>

--- a/src/NextPage.ts
+++ b/src/NextPage.ts
@@ -76,11 +76,11 @@ export interface NextPage<
   setParamsSchema<S extends AnySchema>(schema: S): NextPage<Tag, L, Middleware, S["Type"], SearchParamsA>
   setSearchParamsSchema<S extends AnySchema>(schema: S): NextPage<Tag, L, Middleware, ParamsA, S["Type"]>
 
-  run<
+  build<
     InnerHandler extends HandlerFrom<NextPage<Tag, L, Middleware, ParamsA, SearchParamsA>>,
     OnError = never
   >(
-    build: InnerHandler,
+    handler: InnerHandler,
     onError?: (
       error: MiddlewareErrors<Middleware> | HandlerError<InnerHandler>
     ) => OnError
@@ -140,9 +140,9 @@ const Proto = {
     return makeProto(options)
   },
 
-  run(
+  build(
     this: AnyWithProps,
-    build: (ctx: any) => Effect<any, any, any>,
+    handler: (ctx: any) => Effect<any, any, any>,
     onError?: (error: unknown) => unknown
   ) {
     const middlewares = this.middlewares
@@ -170,7 +170,7 @@ const Proto = {
             : rawSearchParams
           return { params: decodedParams, searchParams: decodedSearchParams }
         })
-        let handlerEffect = build(payload as any) as Effect<any, any, any>
+        let handlerEffect = handler(payload as any) as Effect<any, any, any>
         if (middlewares.length > 0) {
           const options = {
             _type: "page" as const,
@@ -354,7 +354,7 @@ export type SearchParams<P extends Any> = P extends
   SearchParamsA extends undefined ? Promise<Record<string, string>> : SearchParamsA
   : never
 
-// Error typing helpers for run onError
+// Error typing helpers for build onError
 type InferSchemaType<S> = S extends Schema.Schema<infer A, any, any> ? A : never
 
 export type MiddlewareErrors<M> = M extends NextMiddleware.TagClassAny ? InferSchemaType<M["failure"]>

--- a/src/NextServerComponent.ts
+++ b/src/NextServerComponent.ts
@@ -51,11 +51,11 @@ export interface NextServerComponent<
     middleware: Context_.Tag.Identifier<M> extends LayerSuccess<L> ? M : never
   ): NextServerComponent<Tag, L, Middleware | M>
 
-  run<
+  build<
     InnerHandler extends HandlerFrom<NextServerComponent<Tag, L, Middleware>>,
     OnError = never
   >(
-    build: InnerHandler,
+    handler: InnerHandler,
     onError?: (
       error: MiddlewareErrors<Middleware> | HandlerError<InnerHandler>
     ) => OnError
@@ -86,9 +86,9 @@ const Proto = {
     })
   },
 
-  run(
+  build(
     this: AnyWithProps,
-    build: (ctx: any) => Effect<any, any, any>,
+    handler: (ctx: any) => Effect<any, any, any>,
     onError?: (error: unknown) => unknown
   ) {
     const middlewares = this.middlewares
@@ -96,7 +96,7 @@ const Proto = {
     return () => {
       const program = Effect_.gen(function*() {
         const context = yield* Effect_.context<never>()
-        let handlerEffect = build(undefined as any) as Effect<any, any, any>
+        let handlerEffect = handler(undefined as any) as Effect<any, any, any>
         if (middlewares.length > 0) {
           const options = { _type: "component" as const }
           const tags = middlewares as ReadonlyArray<any>
@@ -246,6 +246,6 @@ export type ToHandler<R extends Any> = R extends NextServerComponent<infer _Tag,
  */
 export type ToHandlerFn<R extends Any> = () => Effect<any, any, ExtractProvides<R>>
 
-// Error typing helpers for run onError
+// Error typing helpers for build onError
 export type MiddlewareErrors<M> = M extends NextMiddleware.TagClassAny ? Schema.Schema.Type<M["failure"]> : never
 export type HandlerError<H> = H extends (...args: any) => Effect<infer _A, infer _E, any> ? _E : never

--- a/test/Action.test.ts
+++ b/test/Action.test.ts
@@ -39,7 +39,7 @@ describe("NextAction", () => {
       .setInputSchema(Schema.Struct({ id: Schema.Number }))
       .middleware(AuthMiddleware)
 
-    const result = await action.run(async ({ input }) =>
+    const result = await action.build(async ({ input }) =>
       Effect.gen(function*() {
         const user = yield* CurrentUser
         return { user, input }

--- a/test/Layout.test.ts
+++ b/test/Layout.test.ts
@@ -39,7 +39,7 @@ describe("NextLayout", () => {
       .setParamsSchema(Schema.Struct({ locale: Schema.String }))
       .middleware(ThemeMiddleware)
 
-    const result = await layout.run(({ children, params }) =>
+    const result = await layout.build(({ children, params }) =>
       Effect.gen(function*() {
         const theme = yield* Theme
         return { theme, params, children }

--- a/test/Middleware.ordering.test.ts
+++ b/test/Middleware.ordering.test.ts
@@ -41,7 +41,7 @@ describe("Middleware ordering", () => {
       .middleware(Wrapped)
       .middleware(NonWrapped)
 
-    const result = await page.run(() =>
+    const result = await page.build(() =>
       Effect.gen(function*() {
         yield* Effect.sync(() => order.push("handler"))
         return "ok"
@@ -86,7 +86,7 @@ describe("Middleware ordering", () => {
       .middleware(Wrapped)
       .middleware(NonWrapped)
 
-    const result = await layout.run(() =>
+    const result = await layout.build(() =>
       Effect.gen(function*() {
         yield* Effect.sync(() => order.push("handler"))
         return "ok"
@@ -133,7 +133,7 @@ describe("Middleware ordering", () => {
       .middleware(Wrapped)
       .middleware(NonWrapped)
 
-    const result = await action.run(async () =>
+    const result = await action.build(async () =>
       Effect.gen(function*() {
         yield* Effect.sync(() => order.push("handler"))
         return "ok"
@@ -179,7 +179,7 @@ describe("Middleware ordering", () => {
       .middleware(Wrapped)
       .middleware(NonWrapped)
 
-    const result = await component.run(() =>
+    const result = await component.build(() =>
       Effect.gen(function*() {
         yield* Effect.sync(() => order.push("handler"))
         return "ok"

--- a/test/Page.test.ts
+++ b/test/Page.test.ts
@@ -61,7 +61,7 @@ describe("NextPage", () => {
       .middleware(AuthMiddleware)
       .middleware(OtherMiddleware)
 
-    const result = await page.run(({ params, searchParams }) =>
+    const result = await page.build(({ params, searchParams }) =>
       Effect.gen(function*() {
         const user = yield* CurrentUser
         const other = yield* Other

--- a/test/Program.integration.test.ts
+++ b/test/Program.integration.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from "vitest"
 import * as Next from "../src/Next.js"
 import * as NextMiddleware from "../src/NextMiddleware.js"
 
-// Mirrors example/Program.ts, but as an integration test without invoking run()
+// Mirrors example/Program.ts, but as an integration test without invoking build()
 describe("Program integration", () => {
   // Context tags
   class CurrentUser extends Context.Tag("CurrentUser")<CurrentUser, { id: string; name: string }>() {}
@@ -67,7 +67,7 @@ describe("Program integration", () => {
       .middleware(AuthMiddleware)
       .middleware(OtherMiddleware)
 
-    const result = await page.run(() =>
+    const result = await page.build(() =>
       Effect.gen(function*() {
         const user = yield* CurrentUser
         const other = yield* Other

--- a/test/ServerComponent.test.ts
+++ b/test/ServerComponent.test.ts
@@ -34,7 +34,7 @@ describe("NextServerComponent", () => {
       .component("ServerInfo")
       .middleware(TimeMiddleware)
 
-    const result = await component.run(() =>
+    const result = await component.build(() =>
       Effect.gen(function*() {
         const time = yield* ServerTime
         return { time }


### PR DESCRIPTION
## Summary
- rename `run` functions to `build`
- update docs, examples, and tests for new `build` API

## Testing
- `pnpm lint`
- `pnpm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_689cc473074c832f9cfeb1d4238ef407