### PR TITLE
fix: import unstable_rethrow from public next/navigation API (Next.js 16.3 compat)

### DIFF
--- a/.changeset/fix-next-16-3-rethrow.md
+++ b/.changeset/fix-next-16-3-rethrow.md
@@ -1,0 +1,5 @@
+---
+"@mcrovero/effect-nextjs": patch
+---
+
+Import `unstable_rethrow` from the public `next/navigation` entrypoint instead of the internal `next/dist/client/components/unstable-rethrow.server.js` path. That internal module was removed in Next.js 16.3, which made `next build` fail with `Module not found: Can't resolve 'next/dist/client/components/unstable-rethrow.server.js'` for any app using the library. `unstable_rethrow` has been exported from `next/navigation` since Next.js 15, so this keeps working across the whole supported `^15 || ^16` range.

--- a/src/internal/executor.ts
+++ b/src/internal/executor.ts
@@ -1,6 +1,6 @@
 import { Cause, Chunk, Effect, Exit } from "effect"
 import type * as ManagedRuntime from "effect/ManagedRuntime"
-import { unstable_rethrow } from "next/dist/client/components/unstable-rethrow.server.js"
+import { unstable_rethrow } from "next/navigation.js"
 
 /**
  * @since 0.5.0


### PR DESCRIPTION
## Problem

With Next.js 16.3+, `next build` fails for any app that uses this library:

```
Error: Turbopack build failed with 1 error:
./node_modules/.../@mcrovero/effect-nextjs/dist/esm/internal/executor.js:2:1
Module not found: Can't resolve 'next/dist/client/components/unstable-rethrow.server.js'
```

## Cause

`src/internal/executor.ts` imports `unstable_rethrow` from the internal path
`next/dist/client/components/unstable-rethrow.server.js`. That file existed up to
Next.js 16.2, but was removed in **Next.js 16.3** (the logic was consolidated into
`unstable-rethrow.js`).

The integration fixture (`fixtures/next-app`) pins `next@15.5.4`, so CI doesn't
currently exercise 16.3.

## Fix

Import from the **public** entrypoint instead:

```ts
import { unstable_rethrow } from "next/navigation.js"
```

`unstable_rethrow` has been a documented export of `next/navigation` since
Next.js 15, so this works across the entire supported `^15 || ^16` peer range and
no longer depends on a deep internal path. This matches how the rest of `src/`
already imports from Next (`next/navigation.js`, `next/headers.js`, `next/cache.js`).

## Verification

- `pnpm check` (tsc) and `pnpm lint` pass
- `pnpm test` — all 28 unit tests pass (incl. `Next.defect-propagation`, which
  covers the `executeWithRuntime` defect path)
- `pnpm build` output (`dist/{esm,cjs}/internal/executor.js`) resolves to
  `next/navigation`
- Confirmed `next/navigation` exports `unstable_rethrow` in `next` 15.5.4, 16.2.12
  and 16.3.4
- Applied the equivalent change as a `pnpm patch` in a real app on `next@16.3.4`
  -> `next build` succeeds

## Suggested follow-up (not in this PR)

Bump `fixtures/next-app` to `next@^16.3` (or add a version matrix) so this class
of internal-path breakage is caught by CI.
